### PR TITLE
added provider api keys encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ efbundle
 *.sqlite
 *.sqlite3
 
+## Data Protection keys
+**/keys/key-*.xml
+
 ## User secrets / ASP.NET Core Data Protection
 **/secrets.json
 **/appsettings.*.json

--- a/src/DriftDNS.App/Pages/Providers.razor
+++ b/src/DriftDNS.App/Pages/Providers.razor
@@ -4,8 +4,10 @@
 @using Microsoft.EntityFrameworkCore
 @using System.Text.Json
 @using DriftDNS.Core.Interfaces
+@using DriftDNS.Infrastructure.Security
 @inject DriftDnsDbContext Db
 @inject IEnumerable<IDnsProvider> DnsProviders
+@inject ICredentialProtector CredentialProtector
 
 <PageTitle>Providers – DriftDNS</PageTitle>
 
@@ -247,11 +249,7 @@
         _saving = true;
         try
         {
-            var credentials = _providerType == "Cloudflare"
-                ? JsonSerializer.Serialize(new { ApiToken = _accessKey })
-                : JsonSerializer.Serialize(new { AccessKey = _accessKey, SecretKey = _secretKey });
-
-            if (_editing)
+                if (_editing)
             {
                 var existing = await Db.ProviderAccounts.FindAsync(_editId);
                 if (existing is not null)
@@ -260,16 +258,24 @@
                     existing.ProviderType = _providerType;
                     existing.IsEnabled = _isEnabled;
                     if (!string.IsNullOrWhiteSpace(_accessKey))
-                        existing.EncryptedCredentials = credentials;
+                    {
+                        var json = _providerType == "Cloudflare"
+                            ? JsonSerializer.Serialize(new { ApiToken = _accessKey })
+                            : JsonSerializer.Serialize(new { AccessKey = _accessKey, SecretKey = _secretKey });
+                        existing.EncryptedCredentials = CredentialProtector.Protect(json);
+                    }
                 }
             }
             else
             {
+                var json = _providerType == "Cloudflare"
+                    ? JsonSerializer.Serialize(new { ApiToken = _accessKey })
+                    : JsonSerializer.Serialize(new { AccessKey = _accessKey, SecretKey = _secretKey });
                 Db.ProviderAccounts.Add(new ProviderAccount
                 {
                     Name = _name,
                     ProviderType = _providerType,
-                    EncryptedCredentials = credentials,
+                    EncryptedCredentials = CredentialProtector.Protect(json),
                     IsEnabled = _isEnabled,
                 });
             }

--- a/src/DriftDNS.App/Program.cs
+++ b/src/DriftDNS.App/Program.cs
@@ -1,8 +1,10 @@
 using DriftDNS.App.Workers;
 using DriftDNS.Core.Interfaces;
 using DriftDNS.Infrastructure.Data;
-using DriftDNS.Infrastructure.Services;
 using DriftDNS.Infrastructure.Providers;
+using DriftDNS.Infrastructure.Security;
+using DriftDNS.Infrastructure.Services;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +17,13 @@ builder.Services.AddServerSideBlazor();
 var dbPath = builder.Configuration.GetValue<string>("DatabasePath") ?? "/app/data/app.db";
 builder.Services.AddDbContext<DriftDnsDbContext>(options =>
     options.UseSqlite($"Data Source={dbPath}"));
+
+// Data Protection — keys stored alongside the database
+var keysPath = Path.Combine(Path.GetDirectoryName(dbPath)!, "keys");
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(keysPath))
+    .SetApplicationName("DriftDNS");
+builder.Services.AddSingleton<ICredentialProtector, CredentialProtector>();
 
 // HttpClient for IP resolver
 builder.Services.AddHttpClient();

--- a/src/DriftDNS.Infrastructure/DriftDNS.Infrastructure.csproj
+++ b/src/DriftDNS.Infrastructure/DriftDNS.Infrastructure.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Route53" Version="4.0.8.12" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/DriftDNS.Infrastructure/Providers/CloudflareDnsProvider.cs
+++ b/src/DriftDNS.Infrastructure/Providers/CloudflareDnsProvider.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using DriftDNS.Core.Interfaces;
 using DriftDNS.Core.Models;
+using DriftDNS.Infrastructure.Security;
 using Microsoft.Extensions.Logging;
 
 namespace DriftDNS.Infrastructure.Providers;
@@ -12,15 +13,17 @@ public class CloudflareDnsProvider : IDnsProvider
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<CloudflareDnsProvider> _logger;
+    private readonly ICredentialProtector _credentialProtector;
 
     private const string BaseUrl = "https://api.cloudflare.com/client/v4";
 
     public string Name => "Cloudflare";
 
-    public CloudflareDnsProvider(IHttpClientFactory httpClientFactory, ILogger<CloudflareDnsProvider> logger)
+    public CloudflareDnsProvider(IHttpClientFactory httpClientFactory, ILogger<CloudflareDnsProvider> logger, ICredentialProtector credentialProtector)
     {
         _httpClientFactory = httpClientFactory;
         _logger = logger;
+        _credentialProtector = credentialProtector;
     }
 
     public async Task ValidateCredentialsAsync(ProviderAccount account, CancellationToken cancellationToken = default)
@@ -130,7 +133,7 @@ public class CloudflareDnsProvider : IDnsProvider
 
     private HttpClient CreateClient(ProviderAccount account)
     {
-        var apiToken = ParseCredentials(account.EncryptedCredentials);
+        var apiToken = ParseCredentials(_credentialProtector.Unprotect(account.EncryptedCredentials));
         var client = _httpClientFactory.CreateClient();
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/src/DriftDNS.Infrastructure/Providers/Route53DnsProvider.cs
+++ b/src/DriftDNS.Infrastructure/Providers/Route53DnsProvider.cs
@@ -4,6 +4,7 @@ using Amazon.Route53.Model;
 using Amazon.Runtime;
 using DriftDNS.Core.Interfaces;
 using DriftDNS.Core.Models;
+using DriftDNS.Infrastructure.Security;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
@@ -12,12 +13,14 @@ namespace DriftDNS.Infrastructure.Providers;
 public class Route53DnsProvider : IDnsProvider
 {
     private readonly ILogger<Route53DnsProvider> _logger;
+    private readonly ICredentialProtector _credentialProtector;
 
     public string Name => "Route53";
 
-    public Route53DnsProvider(ILogger<Route53DnsProvider> logger)
+    public Route53DnsProvider(ILogger<Route53DnsProvider> logger, ICredentialProtector credentialProtector)
     {
         _logger = logger;
+        _credentialProtector = credentialProtector;
     }
 
     public async Task ValidateCredentialsAsync(ProviderAccount account, CancellationToken cancellationToken = default)
@@ -171,9 +174,9 @@ public class Route53DnsProvider : IDnsProvider
         return zone.Id;
     }
 
-    private static AmazonRoute53Client CreateClient(ProviderAccount account)
+    private AmazonRoute53Client CreateClient(ProviderAccount account)
     {
-        var creds = ParseCredentials(account.EncryptedCredentials);
+        var creds = ParseCredentials(_credentialProtector.Unprotect(account.EncryptedCredentials));
         var credentials = new BasicAWSCredentials(creds.AccessKey, creds.SecretKey);
         return new AmazonRoute53Client(credentials, RegionEndpoint.USEast1);
     }

--- a/src/DriftDNS.Infrastructure/Security/CredentialProtector.cs
+++ b/src/DriftDNS.Infrastructure/Security/CredentialProtector.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace DriftDNS.Infrastructure.Security;
+
+public interface ICredentialProtector
+{
+    string Protect(string plaintext);
+    string Unprotect(string value);
+}
+
+public class CredentialProtector : ICredentialProtector
+{
+    private readonly IDataProtector _protector;
+
+    public CredentialProtector(IDataProtectionProvider provider)
+    {
+        _protector = provider.CreateProtector("DriftDNS.Credentials.v1");
+    }
+
+    public string Protect(string plaintext) => _protector.Protect(plaintext);
+
+    public string Unprotect(string value)
+    {
+        try
+        {
+            return _protector.Unprotect(value);
+        }
+        catch
+        {
+            // Fallback: unencrypted value from previous installations
+            return value;
+        }
+    }
+}

--- a/tests/DriftDNS.Tests/CloudflareDnsProviderTests.cs
+++ b/tests/DriftDNS.Tests/CloudflareDnsProviderTests.cs
@@ -1,5 +1,6 @@
 using DriftDNS.Core.Models;
 using DriftDNS.Infrastructure.Providers;
+using DriftDNS.Infrastructure.Security;
 using DriftDNS.Tests.Helpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -23,7 +24,7 @@ public class CloudflareDnsProviderTests
         var factory = new Mock<IHttpClientFactory>();
         factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(new HttpClient(_handler));
 
-        _provider = new CloudflareDnsProvider(factory.Object, Mock.Of<ILogger<CloudflareDnsProvider>>());
+        _provider = new CloudflareDnsProvider(factory.Object, Mock.Of<ILogger<CloudflareDnsProvider>>(), new PassthroughCredentialProtector());
         _account = new ProviderAccount
         {
             Name = "Test",
@@ -187,4 +188,10 @@ public class CloudflareDnsProviderTests
         result,
         result_info = new { total_pages = 1 }
     };
+
+    private sealed class PassthroughCredentialProtector : ICredentialProtector
+    {
+        public string Protect(string plaintext) => plaintext;
+        public string Unprotect(string value) => value;
+    }
 }


### PR DESCRIPTION
## Summary

Added provider api keys encryption in database

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Other:

## Changes

- Added encryption key generator at application boot
- Added encryption provider with fallback for old installations

## Testing

- [X] Existing tests pass (`dotnet test`)
- [X] New tests added where appropriate
- [X] Tested manually (describe below)

Tried to update old installation and to add new providers and check it is all working

## Checklist

- [X] Code follows the project conventions (English, nullable enabled, no API controllers)
- [X] No unnecessary files included
- [X] PR targets `main`
